### PR TITLE
Add Work Forest to projects page

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -26,8 +26,17 @@ const projects = [
     featured: true,
   },
   {
+    name: "Work Forest",
+    description: "A pattern for AI-assisted development—parallel or not. Worktrees, plans, and file-based state to stay organized whether you're juggling multiple agents or just one task.",
+    url: "https://workforest.space",
+    github: "https://github.com/joshribakoff/workforest.space",
+    tags: ["Workflow", "AI", "Patterns"],
+    featured: true,
+  },
+  {
     name: "Bearing",
-    description: "Git worktree management CLI for parallel AI-assisted development. Enables multiple Claude sessions to work on isolated branches simultaneously.",
+    description: "Tooling for the Work Forest pattern. Git worktree management CLI and TUI that enables multiple Claude sessions to work on isolated branches simultaneously.",
+    url: "https://bearing.dev",
     github: "https://github.com/joshribakoff/bearing",
     tags: ["CLI", "Git", "Developer Tools"],
     featured: true,


### PR DESCRIPTION
## Summary
- Adds workforest.space as a new featured project
- Updates Bearing description to reference Work Forest pattern
- Adds bearing.dev URL to Bearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)